### PR TITLE
Added optional USER_MODEL setting.

### DIFF
--- a/lazysignup/backends.py
+++ b/lazysignup/backends.py
@@ -1,10 +1,12 @@
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import User
 
+from lazysignup.utils import get_user_class 
+
 class LazySignupBackend(ModelBackend):
 
     def authenticate(self, username=None):
-        users = [u for u in User.objects.filter(username=username)
+        users = [u for u in get_user_class().objects.filter(username=username)
                  if not u.has_usable_password()]
         if len(users) != 1:
             return None
@@ -16,5 +18,6 @@ class LazySignupBackend(ModelBackend):
         # used by the is_lazy_user filter.
         user = super(LazySignupBackend, self).get_user(user_id)
         if user:
+            user = get_user_class().objects.get(pk=user.id)
             user.backend = 'lazysignup.backends.LazySignupBackend'
         return user

--- a/lazysignup/models.py
+++ b/lazysignup/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from lazysignup.decorators import USER_AGENT_BLACKLIST
 from lazysignup.forms import UserCreationForm
 from lazysignup.exceptions import NotLazyError
-from lazysignup.utils import is_lazy_user
+from lazysignup.utils import is_lazy_user, get_user_class
 
 DEFAULT_BLACKLIST = (
     'slurp',
@@ -25,7 +25,7 @@ class LazyUserManager(models.Manager):
     def create_lazy_user(self, username):
         """ Create a lazy user.
         """
-        user = User.objects.create_user(username, '')
+        user = get_user_class().objects.create_user(username, '')
         self.create(user=user)
         return user
 

--- a/lazysignup/utils.py
+++ b/lazysignup/utils.py
@@ -1,5 +1,7 @@
 import hashlib
+from django.conf import settings
 from django.contrib.auth.models import User
+from django.db.models import get_model
 
 def username_from_session(session_key, username_length=None):
     if not username_length:
@@ -21,3 +23,18 @@ def is_lazy_user(user):
     # Otherwise, we have to fall back to checking the database.
     from lazysignup.models import LazyUser
     return bool(LazyUser.objects.filter(user=user).count() > 0)
+
+def get_user_class():
+    """ Try loading an alternate user class according to an optional
+    setting (USER_MODEL).
+    If one isn't provided, or is misconfigured, return the default one.
+    """
+    try:
+        user_class = get_model(*settings.USER_MODEL.split('.', 2))
+    except AttributeError:
+        user_class = None
+
+    if not user_class:
+        user_class = User
+
+    return user_class


### PR DESCRIPTION
I have added an optional USER_MODEL setting, which lets you specify an alternative user model to create and return in lazysignup in place of the regular django.contrib.auth.User.

The setting is optional and if it's misconfigured or not supplied, the code defaults to the previous behavior (django.contrib.auth.User is used).

Example:

in settings.py:
USER_MODEL = 'users.User'

This is very useful if you have, like me, subclassed the User model. Not just me by the way: http://scottbarnham.com/blog/2008/08/21/extending-the-django-user-model-with-inheritance/

Here's hoping this will be significant enough for you to warrant a pull, I'd hate to maintain a fork for a simple change like this one.

Cheers,
Luke Zapart
