### PR TITLE
Email verification support

### DIFF
--- a/lazysignup/views.py
+++ b/lazysignup/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import redirect
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.http import HttpResponseBadRequest
+from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_POST
@@ -20,18 +21,27 @@ from lazysignup.models import LazyUser
 
 @allow_lazy_user
 def convert(request, form_class=UserCreationForm, redirect_field_name='redirect_to',
-            anonymous_redirect=settings.LOGIN_URL):
+            success_url=None,
+            anonymous_redirect=settings.LOGIN_URL,
+            email_verification=False,
+            verification_sent_template_name='lazysignup/verification_sent.html'):
     """ Convert a temporary user to a real one. Reject users who don't
-    appear to be temporary users (ie. they have a usable password)
-    """
-    redirect_to = 'lazysignup_convert_done'
+    appear to be temporary users (ie. they have a usable password).
 
+    ``success_url`` will override any redirect field in the POST parameters,
+    if given. Lacking both, the view will redirect to 'lazysignup_convert_done'
+    by default.
+    """
     # If we've got an anonymous user, redirect to login
     if request.user.is_anonymous():
         return HttpResponseRedirect(anonymous_redirect)
 
+    redirect_to = success_url
+    if redirect_to is None:
+        redirect_to = request.POST.get(
+                redirect_field_name, 'lazysignup_convert_done')
+
     if request.method == 'POST':
-        redirect_to = request.POST.get(redirect_field_name) or redirect_to
         form = form_class(request.POST, instance=request.user)
         if form.is_valid():
             try:
@@ -40,21 +50,34 @@ def convert(request, form_class=UserCreationForm, redirect_field_name='redirect_
                 # If the user already has a usable password, return a Bad Request to
                 # an Ajax client, or just redirect back for a regular client.
                 if request.is_ajax():
-                    return HttpResponseBadRequest(content=_(u"Already converted."))
+                    return HttpResponseBadRequest(content=_(u'Already converted.'))
                 else:
                     return redirect(redirect_to)
 
-            # Re-log the user in, as they'll now not be authenticatable with the Lazy
-            # backend
-            login(request, authenticate(**form.get_credentials()))
+            if email_verification:
+                if request.is_ajax():
+                    # Just send a 200 response to AJAX client requests.
+                    #TODO The response should indicate it's waiting on verification.
+                    return HttpResponse()
 
-            # If we're being called via AJAX, then we just return a 200 directly
-            # to the client. If not, then we redirect to a confirmation page or
-            # to redirect_to, if it's set.
-            if request.is_ajax():
-                return HttpResponse()
+                ctx = {
+                    'email': form.cleaned_data['email'],
+                    'success_url': redirect_to,
+                }
+                ctx = RequestContext(request, ctx)
+                return render_to_response(verification_sent_template_name, ctx)
             else:
-                return redirect(redirect_to)
+                # Re-log the user in, as they'll now not be authenticatable with 
+                # the Lazy backend.
+                login(request, authenticate(**form.get_credentials()))
+
+                # If we're being called via AJAX, then we just return a 200 directly
+                # to the client. If not, then we redirect to a confirmation page or
+                # to redirect_to, if it's set.
+                if request.is_ajax():
+                    return HttpResponse()
+                else:
+                    return redirect(redirect_to)
     else:
         form = form_class()
 
@@ -62,10 +85,9 @@ def convert(request, form_class=UserCreationForm, redirect_field_name='redirect_
         return HttpResponseBadRequest(content=str(form.errors))
     else:
         return direct_to_template(
-            request,
-            'lazysignup/convert.html',
-            { 'form': form,
-              'redirect_to': redirect_to
-            },
-            )
+                request,
+                'lazysignup/convert.html', {
+                    'form': form,
+                    'redirect_to': redirect_to
+                })
 


### PR DESCRIPTION
Hey, I'm using Pinax's account app along with the django-emailconfirmation app to require email verification after signing up before being able to login. This doesn't work with the current lazysignup convert view, since it calls login on the new user immediately after creating it. So I added some kwargs to the view to accomodate email verification and to specify a template to render instead of redirecting if email_verification is on.

I don't expect you to pull this as it is -- I haven't written any tests for this yet, since I'm not sure the way I've done this is how you'd like it (if you even think this update is a good idea in the first place). In particular, I'm not sure how the AJAX requests should be handled in this case -- see the TODO in the commit.

Let me know your thoughts on this and I can try to clean it up some. Thanks!
