### PR TITLE
Run tests only if using test settings.

### DIFF
--- a/lazysignup/test_settings.py
+++ b/lazysignup/test_settings.py
@@ -37,3 +37,6 @@ LAZYSIGNUP_USER_AGENT_BLACKLIST = [
 ROOT_URLCONF = ''
 
 LAZYSIGNUP_USER_MODEL = 'lazysignup.CustomUser'
+
+# Internal setting to discover it test settings are used
+LAZYSIGNUP_TEST_SETTINGS = True

--- a/lazysignup/tests.py
+++ b/lazysignup/tests.py
@@ -96,6 +96,9 @@ class LazyTestCase(TestCase):
     urls = 'lazysignup.test_urls'
 
     def setUp(self):
+        if not getattr(settings, 'LAZYSIGNUP_TEST_SETTINGS', False):
+            self.skipTest('Skipping tests because not using test settings')
+
         self.request = HttpRequest()
         SessionMiddleware().process_request(self.request)
 


### PR DESCRIPTION
Currently tests are always run. Now they are skipped if they are not run with test settings. This allows running tests for many applications at the same time (`./manage test`).

Probably this can be improved once Django 1.4 lands as it supports custom settings for tests. (Although custom model probably has to be configured before test database is setup.)
