### PR TITLE
Fixing default URLs. Issue #11

### DIFF
--- a/lazysignup/urls.py
+++ b/lazysignup/urls.py
@@ -4,8 +4,8 @@ from django.views.generic.simple import direct_to_template
 # URL patterns for lazysignup
 
 urlpatterns = patterns('lazysignup.views',
-    url(r'^convert/$', 'convert', name='lazysignup_convert'),
-    url(r'^convert/done/$', direct_to_template, {
+    url(r'^$', 'convert', name='lazysignup_convert'),
+    url(r'^done/$', direct_to_template, {
         'template': 'lazysignup/done.html',
         }, name='lazysignup_convert_done'),
 )


### PR DESCRIPTION
Default URLs have `/convert/` prefix hard-coded. It is much better to leave it out and allow users to configure it themselves. For example, in my installation I have used `register/`.
