### PR TITLE
Fix 'No module named simple' error when using Django 1.5

### DIFF
--- a/lazysignup/urls.py
+++ b/lazysignup/urls.py
@@ -1,7 +1,5 @@
 import django
-print django.VERSION
 django_version = float('%s.%s' % (django.VERSION[0], django.VERSION[1]))
-print django_version
 
 from django.conf.urls.defaults import patterns, url
 


### PR DESCRIPTION
Hey Dan, this project is awesome, I'm finding it very useful.

I'm playing with Django 1.5 RC1 and the import in urls.py is failing.

According to https://docs.djangoproject.com/en/1.4/topics/generic-views/ it looks like since Django 1.3 the module `django.views.generic.simple` and its function `direct_to_template` were deprecated, and that module was finally removed in 1.5.

It's not the cleanest solution because I wanted to keep backwards-compatibility and reduce headache for people just trying to follow your awesome docs.

-Ben
