### PR TITLE
Added README.rst to manifest.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README
+include README.rst
 include LICENSE.txt
 include docs/HISTORY.txt
 recursive-include lazysignup/templates *.html


### PR DESCRIPTION
Installation from PyPI fails with `IOError: [Errno 2] No such file or directory: 'README.rst'
`.
