### PR TITLE
Fixed packaging error

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include README.rst
 include LICENSE.txt
 include docs/HISTORY.txt
 recursive-include lazysignup/templates *.html
+prune custom_user_tests
+prune lazysignup/tests

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+1.0.1
+-----
+* Fix packaging issue
+
 1.0.0
 -----
 * Add support for Django 1.7 migrations

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -48,3 +48,11 @@ To build and view the documentation, run ::
     python setup.py build_sphinx
     open docs/_build/html/index.html
 
+Releasing
+---------
+
+Releasing to pypi is as simple as::
+
+    pip install -e .[all]
+    python setup.py sdist bdist_wheel upload
+

--- a/lazysignup/version.py
+++ b/lazysignup/version.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/setup.py
+++ b/setup.py
@@ -63,16 +63,7 @@ setup(
         "License :: OSI Approved :: BSD License"
     ],
     license='BSD',
-    packages=find_packages(
-        'lazysignup',
-        exclude='tests',
-    ),
-    package_dir={'': 'lazysignup'},
-    package_data={
-        'lazysignup': ['templates/lazysignup/*html'],
-        '': ['*.txt', '*.rst'],
-    },
-    namespace_packages=[],
+    packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,


### PR DESCRIPTION
@danfairs So sorry! I was trying to prune out the test directories in `setup.py` and accidentally dropped all the files matching `/lazysignup/*.py`! I built a sdist locally and verified that everything that should be present is. This should fix the release for 1.0.1