### PR TITLE
add csrf_token to convert form

### DIFF
--- a/lazysignup/templates/lazysignup/convert.html
+++ b/lazysignup/templates/lazysignup/convert.html
@@ -4,6 +4,7 @@
   <head>Convert</head>
   <body>
     <form method="post" action="{% url 'lazysignup_convert' %}">
+      {% csrf_token %}
       {{ form.as_p }}
       <input type="hidden" name="redirect_to" value="{{ redirect_to }}">
       <input type="submit" value="{% trans "Submit" %}" />


### PR DESCRIPTION
This adds {% csrf_token %} to the convert form template, to prevent "Forbidden (403)  CSRF verification failed. Request aborted." errors when a user submits the convert form.