### PR TITLE
Ability to use allow_lazy_user with class methods

### DIFF
--- a/lazysignup/decorators.py
+++ b/lazysignup/decorators.py
@@ -49,6 +49,41 @@ def allow_lazy_user(func):
     return wraps(func)(wrapped)
 
 
+def allow_lazy_user_method(func):
+    def wrapped(instance, request, *args, **kwargs):
+        assert hasattr(request, 'session'), ("You need to have the session "
+                                             "app intsalled")
+        if getattr(settings, 'LAZYSIGNUP_ENABLE', True):
+            # If the user agent is one we ignore, bail early
+            ignore = False
+            request_user_agent = request.META.get('HTTP_USER_AGENT', '')
+            for user_agent in USER_AGENT_BLACKLIST:
+                if user_agent.search(request_user_agent):
+                    ignore = True
+                    break
+
+            # If there's already a key in the session for a valid user, then
+            # we don't need to do anything. If the user isn't valid, then
+            # get_user will return an anonymous user
+            if get_user(request).is_anonymous() and not ignore:
+                # If not, then we have to create a user, and log them in.
+                from lazysignup.models import LazyUser
+                user, username = LazyUser.objects.create_lazy_user()
+                request.user = None
+                user = authenticate(username=username)
+                assert user, ("Lazy user creation and authentication "
+                              "failed. Have you got "
+                              "lazysignup.backends.LazySignupBackend in "
+                              "AUTHENTICATION_BACKENDS?")
+                # Set the user id in the session here to prevent the login
+                # call cycling the session key.
+                request.session[SESSION_KEY] = user.id
+                login(request, user)
+        return func(instance, request, *args, **kwargs)
+
+    return wraps(func)(wrapped)
+
+
 def require_lazy_user(*redirect_args, **redirect_kwargs):
     def decorator(func):
         @wraps(func, assigned=available_attrs(func))


### PR DESCRIPTION
The ```allow_lazy_user``` decorator is not designed to be used with class methods that prevents one from using it with class based views. We have added a new decorator ```allow_lazy_user_method``` that accepts the instance/self as required and propagates it through the wrap logic. We have used this version in our project successfully where we needed lazy signup to work with a django rest framework view class.