### PR TITLE
make urlpatterns work with django 1.10

### DIFF
--- a/lazysignup/urls.py
+++ b/lazysignup/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import patterns, url
-
+from django.conf.urls import url
 from django.views.generic import TemplateView
+
+from .views import convert
 
 # URL patterns for lazysignup
 
-urlpatterns = patterns(
-    'lazysignup.views',
-    url(r'^$', 'convert', name='lazysignup_convert'),
+urlpatterns = [
+    url(r'^$', convert, name='lazysignup_convert'),
     url(r'^done/$',
         TemplateView.as_view(template_name='lazysignup/done.html'),
         name='lazysignup_convert_done'),
-)
+]


### PR DESCRIPTION
django.conf.urls.patterns() has been removed in 1.10 (deprecated since 1.8)

Fixes #49