### PR TITLE
Revert removal of LAZYSIGNUP_USER_NAME_FIELD

### DIFF
--- a/lazysignup/backends.py
+++ b/lazysignup/backends.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.backends import ModelBackend
 from lazysignup.models import LazyUser
-from django.contrib.auth import get_user_model
+from lazysignup.constants import LAZYSIGNUP_USER_NAME_FIELD
 
 
 class LazySignupBackend(ModelBackend):
@@ -9,7 +9,7 @@ class LazySignupBackend(ModelBackend):
         user_class = LazyUser.get_user_class()
         try:
             return user_class.objects.get(**{
-                get_user_model().USERNAME_FIELD: username
+                LAZYSIGNUP_USER_NAME_FIELD: username
             })
         except user_class.DoesNotExist:
             return None

--- a/lazysignup/constants.py
+++ b/lazysignup/constants.py
@@ -2,6 +2,7 @@ import re
 from django.conf import settings
 
 LAZYSIGNUP_USER_MODEL = getattr(settings, 'LAZYSIGNUP_USER_MODEL', settings.AUTH_USER_MODEL)
+LAZYSIGNUP_USER_NAME_FIELD = getattr(settings, 'LAZYSIGNUP_USER_NAME_FIELD', 'username')
 LAZYSIGNUP_CUSTOM_USER_CREATION_FORM = getattr(
     settings,
     'LAZYSIGNUP_CUSTOM_USER_CREATION_FORM',

--- a/lazysignup/models.py
+++ b/lazysignup/models.py
@@ -32,7 +32,7 @@ class LazyUserManager(models.Manager):
         """
         return hash(str(self))
 
-    username_field = get_user_model().USERNAME_FIELD
+    username_field = constants.LAZYSIGNUP_USER_NAME_FIELD
 
     def create_lazy_user(self):
         """ Create a lazy user. Returns a 2-tuple of the underlying User


### PR DESCRIPTION
Undid most of the changes in this commit as getting error that models not loaded in django 1.10 and 1.11 .  If reverted to earlier version lazysignup then errors related to django version.  
Basicially undoes these changes to https://github.com/danfairs/django-lazysignup/commit/b04bc68d821a622610e3ad90fdac8190b2a38cef#diff-aeccbf6d9d46b31ff3c14fba9d664a12
and defaults LAZYSIGNUP_USER_NAME_FIELD to "username"

This may not be the best approach but it works for me.