### PR TITLE
LazyUser.user attribute needs on_delete argument for  Django>=2.0

### DIFF
--- a/lazysignup/migrations/0001_initial.py
+++ b/lazysignup/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(serialize=False, primary_key=True, verbose_name='ID', auto_created=True)),
                 ('created', models.DateTimeField(default=django.utils.timezone.now, db_index=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True, on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/lazysignup/migrations/0002_auto_20150430_1100.py
+++ b/lazysignup/migrations/0002_auto_20150430_1100.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='lazyuser',
             name='user',
-            field=models.OneToOneField(to=settings.AUTH_USER_MODEL),
+            field=models.OneToOneField(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
         ),
     ]

--- a/lazysignup/models.py
+++ b/lazysignup/models.py
@@ -78,7 +78,7 @@ class LazyUserManager(models.Manager):
 
 @six.python_2_unicode_compatible
 class LazyUser(models.Model):
-    user = models.OneToOneField(constants.LAZYSIGNUP_USER_MODEL)
+    user = models.OneToOneField(constants.LAZYSIGNUP_USER_MODEL, on_delete=models.CASCADE)
     created = models.DateTimeField(default=now, db_index=True)
     objects = LazyUserManager()
 

--- a/lazysignup/tests/urls.py
+++ b/lazysignup/tests/urls.py
@@ -19,8 +19,10 @@ admin.autodiscover()
 # URL test patterns for lazysignup. Use this file to ensure a consistent
 # set of URL patterns are used when running unit tests.
 
+from django.contrib import admin
+
 urlpatterns = [
-    url(r'^admin/?', include(admin.site.urls)),
+    url(r'^admin/?', admin.site.urls),
     url(r'^convert/', include('lazysignup.urls')),
     url(r'^custom_convert/', views.convert, {
         'template_name': 'lazysignup/done.html'


### PR DESCRIPTION
After installing and running the server, a TypeError error is raised in `"lazysignup\models.py", line 81, in LazyUser`

    TypeError: __init__() missing 1 required positional argument: 'on_delete'

LazyUser.user needs the on_delete argument which I've added. 