### PR TITLE
Improve badge in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://api.travis-ci.org/LaundroMat/django-lazysignup.png
+.. image:: https://img.shields.io/badge/build-passing-brightgreen.svg
 
 Introduction
 ============


### PR DESCRIPTION
The png based badge looks corrupted on hi-def screens :(

<img width="285" alt="screen shot 2019-02-02 at 4 23 02 pm" src="https://user-images.githubusercontent.com/23400562/52161324-d185ba80-2706-11e9-9b62-b7e64c927094.png">
