### PR TITLE
Make package work for Django 4.0 w/ compatibility code

### DIFF
--- a/custom_user_tests/forms.py
+++ b/custom_user_tests/forms.py
@@ -1,7 +1,10 @@
 from custom_user_tests.models import CustomUser
 from django import forms
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
+try:  # removed in Django 4.0, deprecated since 3.0
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 
 class GoodUserCreationForm(forms.ModelForm):

--- a/custom_user_tests/models.py
+++ b/custom_user_tests/models.py
@@ -7,8 +7,11 @@ from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
 from django.contrib.auth.models import UserManager
 from django.core import validators
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
+try:  # removed in Django 4.0, deprecated since 3.0
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 
 class CustomUser(AbstractBaseUser, PermissionsMixin):

--- a/custom_user_tests/settings.py
+++ b/custom_user_tests/settings.py
@@ -42,26 +42,28 @@ DATABASES = {
     'default': db_config
 }
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'custom_user_tests',
     'lazysignup',
     'django.contrib.auth',
     'django.contrib.sessions',
     'django.contrib.contenttypes',
+    'django.contrib.messages',
 	'django.contrib.admin',
-)
+]
 
 SITE_ID = 1
 
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
     "lazysignup.backends.LazySignupBackend",
-)
+]
 
 MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
 LAZYSIGNUP_USER_AGENT_BLACKLIST = [

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,15 +16,14 @@ Once that's done, you need to add ``lazysignup`` to your ``INSTALLED_APPS``.
 You will also need to add ``lazysignup``'s authentication backend to your
 site's ``AUTHENTICATION_BACKENDS`` setting::
 
-  AUTHENTICATION_BACKENDS = (
+  AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
     'lazysignup.backends.LazySignupBackend',
-  )
+  ]
 
 Finally, you need to add lazysignup to your URLConf, using something like
 this::
 
-  urlpatterns += (
-      url(r'^convert/', include('lazysignup.urls')),
-  )
-
+  urlpatterns += [
+      path('convert/', include('lazysignup.urls')),
+  ]

--- a/lazysignup/signals.py
+++ b/lazysignup/signals.py
@@ -1,3 +1,6 @@
 import django.dispatch
 
-converted = django.dispatch.Signal(providing_args=['user'])
+try:  # keyword removed in Django 4.0, deprecated since 3.1
+    converted = django.dispatch.Signal(providing_args=['user'])
+except TypeError:
+    converted = django.dispatch.Signal()  # 'user'

--- a/lazysignup/tests/tests.py
+++ b/lazysignup/tests/tests.py
@@ -31,7 +31,7 @@ from lazysignup.models import LazyUser
 from lazysignup.signals import converted
 from lazysignup.utils import is_lazy_user
 
-if settings.AUTH_USER_MODEL is 'auth.User':
+if settings.AUTH_USER_MODEL == 'auth.User':
     from lazysignup.tests.forms import GoodUserCreationForm
 else:
     from custom_user_tests.forms import GoodUserCreationForm

--- a/lazysignup/tests/urls.py
+++ b/lazysignup/tests/urls.py
@@ -1,9 +1,12 @@
-from django.conf.urls import url, include
+try:  # removed in Django 4.0, deprecated since 3.1
+    from django.conf.urls import url, include
+except ImportError:
+    from django.urls import include, re_path as url
 from django.contrib.auth.forms import UserCreationForm
 
 from django.conf import settings
 
-if settings.AUTH_USER_MODEL is 'auth.User':  # pragma: no cover
+if settings.AUTH_USER_MODEL == 'auth.User':  # pragma: no cover
     from lazysignup.tests.forms import GoodUserCreationForm
 else:  # pragma: no cover
     from custom_user_tests.forms import GoodUserCreationForm

--- a/lazysignup/urls.py
+++ b/lazysignup/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls import url
+try:  # removed in Django 4.0, deprecated since 3.1
+    from django.conf.urls import url
+except ImportError:
+    from django.urls import re_path as url
+
 from django.views.generic import TemplateView
 
 from .views import convert

--- a/lazysignup/views.py
+++ b/lazysignup/views.py
@@ -5,8 +5,11 @@ from django.shortcuts import redirect, render
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.http import HttpResponseBadRequest
-from django.utils.translation import ugettext_lazy as _
 from django.utils.module_loading import import_string
+try:  # removed in Django 4.0, deprecated since 3.0
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from lazysignup.decorators import allow_lazy_user
 from lazysignup.exceptions import NotLazyError
@@ -46,7 +49,7 @@ def convert(request, form_class=None,
                 # If the user already has a usable password, return a Bad
                 # Request to an Ajax client, or just redirect back for a
                 # regular client.
-                if request.is_ajax():
+                if is_ajax(request):
                     return HttpResponseBadRequest(
                         content=_(u"Already converted."))
                 else:
@@ -59,20 +62,20 @@ def convert(request, form_class=None,
             # If we're being called via AJAX, then we just return a 200
             # directly to the client. If not, then we redirect to a
             # confirmation page or to redirect_to, if it's set.
-            if request.is_ajax():
+            if is_ajax(request):
                 return HttpResponse()
             else:
                 return redirect(redirect_to)
 
         # Invalid form, now check to see if is an ajax call
-        if request.is_ajax():
+        if is_ajax(request):
             return HttpResponseBadRequest(content=str(form.errors))
     else:
         form = form_class()
 
     # If this is an ajax request, prepend the ajax template to the list of
     # templates to be searched.
-    if request.is_ajax():
+    if is_ajax(request):
         template_name = [ajax_template_name, template_name]
     return render(
         request,
@@ -82,3 +85,12 @@ def convert(request, form_class=None,
             'redirect_to': redirect_to
         },
     )
+
+
+def is_ajax(request):
+    """
+    ``request.is_ajax()`` was removed in Django 4.0, deprecated since 3.1
+
+    Solution taken from: https://docs.djangoproject.com/en/3.1/releases/3.1/
+    """
+    return request.headers.get('x-requested-with') == 'XMLHttpRequest'


### PR DESCRIPTION
django-lazysignup fails to run (at least) since Django 4.0, mostly due to code removed from the Django code base, what was announced since Django 3.1. This PR provides the fixes.

The changes are almost certainly backward-compatible. Ideally, tests should confirm that, though. You may want to use a modernized CI setup for that, like the one contributed with #69.